### PR TITLE
docs: update README to reflect GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/pages/index.tsx`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+## Features
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) instead of React pages.
-
-This project uses [`next/font`](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- **Hardware-Accelerated Zoom**: Uses device camera capabilities for smooth, high-quality zoom
+- **Flashlight/Torch Control**: Toggle camera flash on supported devices
+- **Auto-Hide Controls**: UI automatically fades out after inactivity for unobstructed viewing
+- **Wake Lock**: Prevents screen from sleeping during use
+- **PWA Support**: Install on your device for a native app experience
 
 ## Learn More
 
@@ -37,8 +39,26 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Building for Production
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Build and export the static site:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
+```bash
+npm run build
+npm run export
+```
+
+## Deploy to GitHub Pages
+
+This project is configured for deployment to GitHub Pages using static export:
+
+```bash
+npm run deploy
+```
+
+This command will:
+1. Build the production version
+2. Export the static site
+3. Publish to the `gh-pages` branch
+
+**Note**: This project uses `output: "export"` in `next.config.ts` for static site generation. API routes are not supported in production as this is a client-side only PWA.


### PR DESCRIPTION
Fixes #3

Updated README.md to accurately reflect the project's GitHub Pages deployment configuration:

- Removed outdated API routes references
- Removed Vercel deployment information
- Added GitHub Pages deployment instructions
- Added features section highlighting PWA capabilities
- Updated file path to src/pages/index.tsx
- Added note about static export configuration

Generated with [Claude Code](https://claude.ai/code)